### PR TITLE
Properly seed pokeemerald's rng

### DIFF
--- a/src/title_screen.c
+++ b/src/title_screen.c
@@ -525,6 +525,7 @@ void CB2_InitTitleScreen(void)
     default:
     case 0:
         SetVBlankCallback(NULL);
+        StartTimer1();
         SetGpuReg(REG_OFFSET_BLDCNT, 0);
         SetGpuReg(REG_OFFSET_BLDALPHA, 0);
         SetGpuReg(REG_OFFSET_BLDY, 0);


### PR DESCRIPTION
## Description
Match Firered's and Leafgreen's way of seeding the rng, this is the way GameFreak originally wanted to do this for Emerald.
The "shiny frame" phenomenon will be fixed by this.